### PR TITLE
Initial Testing Fixes

### DIFF
--- a/csharp/AIPProvider/src/Fox4/Fox4.cs
+++ b/csharp/AIPProvider/src/Fox4/Fox4.cs
@@ -1,6 +1,7 @@
 ﻿using System.Numerics;
 using AIPProvider.Extensions;
 using Microsoft.ML.OnnxRuntime;
+using Microsoft.ML.OnnxRuntime.Tensors;
 using UnityGERunner.UnityApplication;
 
 namespace AIPProvider.Fox4;
@@ -19,8 +20,11 @@ public sealed class Fox4
     private const float SPEED_NORM = 686;       // Mach 2
 
     private readonly IAIPProvider _logger;
-    private readonly InferenceSession _session;
     private readonly RunOptions _options;
+    private readonly InferenceSession _session;
+
+    private readonly string _inputName;
+    private readonly string[] _outputNames;
 
     private float? _previousTime;
     private Vector3? _previousEulerAngles;
@@ -33,7 +37,13 @@ public sealed class Fox4
         _session = new InferenceSession(MODEL_PATH);
         _options = new RunOptions();
 
-        Name = $"Fox4 v{_session.ModelMetadata}";
+        _inputName = _session.InputMetadata.Keys.First();
+        _outputNames = _session.OutputNames.ToArray();
+
+        foreach (var sessionInputName in _session.InputNames)
+            _logger.Log(sessionInputName);
+
+        Name = $"Fox4 v{_session.ModelMetadata.Version}";
     }
 
     public void Dispose()
@@ -52,24 +62,33 @@ public sealed class Fox4
 
         // Calculate change in euler angle since last frame
         var euler = state.kinematics.rotation.quat.eulerAngles.To();
-        if (!_previousEulerAngles.HasValue)
+        var angleRate = Vector3.Zero;
+        if (!_previousEulerAngles.HasValue || dt == 0)
+        {
             _previousEulerAngles = euler;
-        var deltaAngle = _previousEulerAngles.Value - euler;
-        var angleRate = deltaAngle / dt;
+        }
+        else
+        {
+            var deltaAngle = _previousEulerAngles.Value - euler;
+            angleRate = deltaAngle / dt;
+        }
 
         // Create input tensor
         var inputTensor = BuildInputTensor(ref state, angleRate);
         var inputs = new Dictionary<string, OrtValue>
         {
-            { "input", inputTensor }
+            { _inputName, OrtValue.CreateTensorValueFromMemory(OrtMemoryInfo.DefaultInstance, inputTensor.Buffer, [1, inputTensor.Length]) }
         };
 
         // Inference forward pass
-        using var outputs = _session.Run(_options, inputs, _session.OutputNames);
+        //using var outputs = _session.Run(_options, inputs, _outputNames);
+
+        // HACK!!
+        using var session = new InferenceSession(MODEL_PATH);
+        using var outputs = session.Run(_options, inputs, _outputNames);
 
         // Read outputs
-        using var output = outputs[0];
-        var reader = new OutputTensorReader(output);
+        var reader = new OutputTensorReader(outputs[0].GetTensorDataAsSpan<float>());
 
         // Pull trigger
         var builder = new ActionsBuilder(state);
@@ -84,14 +103,14 @@ public sealed class Fox4
         };
     }
 
-    private OrtValue BuildInputTensor(ref OutboundState state, Vector3 angleRate)
+    private DenseTensor<float> BuildInputTensor(ref OutboundState state, Vector3 angleRate)
     {
         var radar_altitude = state.kinematics.position.y - _logger.HeightAt(state.kinematics.position);
 
         var speed = state.kinematics.velocity.vec3.magnitude;
         var dir = state.kinematics.velocity.vec3 / speed;
 
-        var target = state.visualTargets[0];
+        var target = state.visualTargets.Length == 0 ? default : state.visualTargets[0];
         var localDir = state.kinematics.rotation.quat * target.direction;
 
         var targetLocalRot = Quaternion.Inverse(state.kinematics.rotation.To()) * target.orientation.To();
@@ -138,6 +157,6 @@ public sealed class Fox4
             //todo: aiming/lead indicator info
         ];
 
-        return OrtValue.CreateTensorValueFromMemory<float>(OrtMemoryInfo.DefaultInstance, data, [1, data.Length]);
+        return new DenseTensor<float>(data, [ 1, data.Length ]);
     }
 }


### PR DESCRIPTION
Some fixes from initial testing with Solon:
 - Fixed NaN angle rate on first frame
 - Handling no visual targets without crashing (should only be an issue on frame 0)
 - Re-creating `InferenceSession` every frame. This is a hack until I work out a better fix for onnx runtime.