### PR TITLE
Fix Use After Dispose

### DIFF
--- a/csharp/AIPProvider/src/Fox4/Fox4.cs
+++ b/csharp/AIPProvider/src/Fox4/Fox4.cs
@@ -12,12 +12,9 @@ public sealed class Fox4
     : IDisposable
 {
     private readonly IAIPProvider _provider;
-    private readonly RunOptions _options;
-    private readonly InferenceSession _session;
 
-    private readonly string _inputName;
+    private readonly InferenceSession _session;
     private readonly IInputTensorBuilder _inputBuilder;
-    private readonly string[] _outputNames;
     private readonly IOutputTensorReader _outputReader;
 
     private float? _previousTime;
@@ -25,17 +22,13 @@ public sealed class Fox4
 
     private readonly DatasetLogger? _logDataset;
 
-    public string Name { get; init; }
+    public string Name { get; }
 
     public Fox4(IAIPProvider provider, int id, string modelPath, bool logDataset = false)
     {
         _provider = provider;
 
         _session = new InferenceSession(modelPath);
-        _options = new RunOptions();
-
-        _inputName = _session.InputMetadata.Keys.First();
-        _outputNames = _session.OutputNames.ToArray();
 
         Name = $"Fox4 v{_session.ModelMetadata.Version}";
 
@@ -49,7 +42,6 @@ public sealed class Fox4
     public void Dispose()
     {
         _session.Dispose();
-        _options.Dispose();
         _logDataset?.Dispose();
     }
 
@@ -79,16 +71,12 @@ public sealed class Fox4
         using var inputTensorOrt = OrtValue.CreateTensorValueFromMemory(OrtMemoryInfo.DefaultInstance, inputTensor.Buffer, [ 1, inputTensor.Length ]);
         var inputs = new Dictionary<string, OrtValue>
         {
-            { _inputName, inputTensorOrt }
+            { "input", inputTensorOrt }
         };
 
         // Inference forward pass
-        //using var outputs = _session.Run(_options, inputs, _outputNames);
-
-        // HACK!! This works around the issue
-        using var session = new InferenceSession("model.onnx");
-        using var outputs = session.Run(_options, inputs, _outputNames);
-
+        using var options = new RunOptions();
+        using var outputs = _session.Run(options, inputs, [ "output" ]);
         var outputsSpan = outputs[0].GetTensorDataAsSpan<float>();
 
         // Log tensor data to CSV

--- a/csharp/AIPProvider/src/Fox4/Fox4Provider.cs
+++ b/csharp/AIPProvider/src/Fox4/Fox4Provider.cs
@@ -10,6 +10,7 @@ public class Fox4Provider
     private Fox4? _pilot;
 
     private bool _setup;
+    private bool _stopped;
 
     public override SetupActions Start(SetupInfo info)
     {
@@ -35,6 +36,10 @@ public class Fox4Provider
 
     public override void Stop()
     {
+        if (_stopped)
+            return;
+        _stopped = true;
+
         base.Stop();
 
         _pilot?.Dispose();
@@ -42,6 +47,10 @@ public class Fox4Provider
 
     public override InboundState Update(OutboundState state)
     {
+        // Don't do anything after stop is called
+        if (_stopped)
+            return default;
+
         // Skip the very first step of the sim to avoid weird setup issues on the first frame
         if (!_setup)
         {

--- a/csharp/AIPProvider/src/Fox4/ONNX/Tensors/DatasetLogger.cs
+++ b/csharp/AIPProvider/src/Fox4/ONNX/Tensors/DatasetLogger.cs
@@ -38,13 +38,14 @@ public sealed class DatasetLogger
         builder.AppendJoin(", ", outputTensor);
         _outputs.WriteLine(builder);
 
+        // Stop is not always called by the sim. Flush the buffers after every line to ensure we don't get a broken file.
         _inputs.Flush();
         _outputs.Flush();
     }
 
     public void Dispose()
     {
-        _inputs.Flush();
-        _outputs.Flush();
+        _inputs.Dispose();
+        _outputs.Dispose();
     }
 }


### PR DESCRIPTION
Added a flag that prevents anything happening after `Stop` is called. This fixed some use-after-dispose related issues and prevents any more of this class of bug in the future.

Previously the dataset logger could not be disposed, because it was used after the call to `Stop`. This is no longer an issue and it can be properly disposed.

`InferenceSession` problems (resolve #3) were due to using the session after disposal. No longer, this should speed up the sim by 10x.