### PR TITLE
KL Divergence Early Stopping

### DIFF
--- a/rlpy/training.py
+++ b/rlpy/training.py
@@ -45,14 +45,14 @@ class PPOParameters():
 
         # List of (attribute, min, max) for mutation
         param_defs = [
-            ("gamma", 0.75, 1),
-            ("gae_lambda", 0.75, 1),
-            ("learning_rate", 1e-6, 1e-3),
-            ("clip_range", 0.1, 0.3),
-            ("value_coeff", 0.1, 0.7),
-            ("entropy_coeff", 0.001, 0.1),
-            ("large_entropy_coeff", 0.0, 0.1),
-            ("max_kl_divergence", 0.0001, 0.5),
+            ("gamma",               0.75, 1),
+            ("gae_lambda",          0.75, 1),
+            ("learning_rate",       0.0000001, 0.001),
+            ("clip_range",          0.1, 0.3),
+            ("value_coeff",         0.1, 0.7),
+            ("entropy_coeff",       0.0001, 0.1),
+            ("large_entropy_coeff", 0.0001, 0.1),
+            ("max_kl_divergence",   0.0001, 0.5),
         ]
 
         # Apply mutation to a copy of self

--- a/rlpy/training.py
+++ b/rlpy/training.py
@@ -213,9 +213,11 @@ def train(model, dataset_in: pd.DataFrame, dataset_out: pd.DataFrame, dataset_ex
                  + parameters.large_entropy_coeff * std_penalty
             )
 
-            # Calculate an approximation of the KL divergence between the old and new policies
+            # https://github.com/Chris-hughes10/simple-ppo/blob/main/simple_ppo/ppo.py#L649-L660
+            # Calculate the KL divergence of the model so far
             log_ratio = (new_log_probs - batch_old_log_probs)
-            kl_divergence = torch.mean((ratio - 1) - log_ratio)
+            with torch.no_grad():
+                kl_divergence = ((ratio - 1) - log_ratio).mean()
 
             # If the KL divergence exceeds the target stop the training for this epoch. This prevents the model
             # from changing too much based on a single set of training data


### PR DESCRIPTION
Added an early stopping policy to training which prevents overtraining on one particular set of data. if the model output changes a lot within a single generation then that generation training is ended early.

This should stabilise training, preventing huge spikes and then dips in reward (at the cost of adding another hyperparameter)